### PR TITLE
[Fix][#39] SessionInfo.expirationTime access on android crashing

### DIFF
--- a/lib/models/gigya_models.dart
+++ b/lib/models/gigya_models.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 /// Available interruptions.
 enum Interruption {
@@ -160,8 +159,7 @@ class SessionInfo {
         'expires_in': this.expirationTime,
       };
 
-  double get expirationTime =>
-      Platform.isIOS ? double.parse(expiresIn) : expiresIn;
+  double get expirationTime => double.parse(expiresIn);
 }
 
 /// Account profile schema object.


### PR DESCRIPTION
https://github.com/SAP/gigya-flutter-plugin/issues/39

Fix for the above reported issue.

Crash on android:

Uncaught Error: TypeError: "0": type ‘String' is not a subtype of type 'double'

expireIn value is received as string and incase of android it doesn't parse to double.

```
  Future<void> setSession(
      String sessionToken, String sessionSecret, double expiration)
```

Accessing above method with Session instance values throws the exception in android works fine in iOS.
