### PR TITLE
Add Android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0.0'
 buildscript {
     ext {
         kotlin_version = '1.8.0'
-        gradle_version = '7.3.1'
+        gradle_version = '7.4.2'
     }
 
     repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,18 @@ group 'com.sap.gigya_flutter_plugin'
 version '1.0.0'
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext {
+        kotlin_version = '1.8.0'
+        gradle_version = '7.3.1'
+    }
+
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     
     // Gigya SDK core implementation.
     api 'com.github.SAP.gigya-android-sdk:sdk-core:core-v6.2.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
+    namespace 'com.sap.gigya_flutter_plugin'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -70,7 +70,7 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.multidex:multidex:2.0.1"
 
     // Needed when implementing Gigya SDK activity based operations.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -31,14 +31,12 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-
-    lintOptions {
-        disable 'InvalidPackage'
-    }
-
     packagingOptions {
-        exclude 'META-INF/com.android.tools/proguard/coroutines.pro'
+        resources {
+            excludes += ['META-INF/com.android.tools/proguard/coroutines.pro']
+        }
     }
+
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -62,6 +60,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+    namespace 'com.sap.gigya_flutter_plugin_example'
+    lint {
+        disable 'InvalidPackage'
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,16 @@
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext {
+        kotlin_version = '1.8.0'
+        gradle_version = '7.3.1'
+    }
+
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlin_version = '1.8.0'
-        gradle_version = '7.3.1'
+        gradle_version = '7.4.2'
     }
 
     repositories {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -102,7 +102,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "1.0.0"
   google_sign_in:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This PR adds the Android `namespace` attribute to the build.gradle.
It also bumps Kotlin to 1.8.0 and bumps the Android Gradle Plugin to 7.5

Having AGP set to 7.5 enables the AGP upgrade assistant in Android Studio to recognise Gradle 8 (8.0.1-rc1).
Once it is time to migrate to Gradle 8, then we can run the assistant to do it for us.

Currently it is still too soon to migrate to Gradle 8 specifically.

Context for this PR is here: https://docs.flutter.dev/release/breaking-changes/android-java-gradle-migration-guide
We will hit that in the future 