### PR TITLE
Fix GigyaError with null values

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
@@ -102,7 +102,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "1.0.0"
   google_sign_in:
     dependency: "direct main"
     description:
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -147,10 +147,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -163,18 +163,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -253,5 +253,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://www.sap.com
 publish_to: none
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/ios/Classes/GigyaSdkWrapper.swift
+++ b/ios/Classes/GigyaSdkWrapper.swift
@@ -10,6 +10,36 @@ public class PluginErrors {
     static let missingParameterMessage = "request parameter missing"
     static let unsupportedError = "702"
     static let unsupportedErrorMessage = "not supported in this iOS version"
+    
+    /**
+        Wrap the given ``error`` in a ``FlutterError``.
+     */
+    static func wrapNetworkError(error: NetworkError) -> FlutterError {
+        switch error {
+        case .gigyaError(data: let data):
+            var details: [String: Any] = [
+                "callId": data.callId,
+                "statusCode": data.statusCode.rawValue,
+            ]
+            
+            // Append the `requestData`.
+            for (key, value) in data.toDictionary() {
+                details[key] = value
+            }
+            
+            return FlutterError(code: "\(data.errorCode)", message: data.errorMessage, details: details)
+        case .providerError(data: let data):
+            return FlutterError(code: PluginErrors.generalError, message: data, details: nil)
+        case .networkError(error: let error):
+            return FlutterError(code: PluginErrors.generalError, message: error.localizedDescription, details: nil)
+        case .emptyResponse:
+            return FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil)
+        case .jsonParsingError(error: let error):
+            return FlutterError(code: PluginErrors.generalError, message: error.localizedDescription, details: nil)
+        case .createURLRequestFailed:
+            return FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil)
+        }
+    }
 }
 
 public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
@@ -20,7 +50,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
     
     init(accountSchema: T.Type) {
         // Initializing the Gigya SDK instance.
-        GigyaDefinitions.versionPrefix = "flutter_0.3.0_"
+        GigyaDefinitions.versionPrefix = "flutter_1.0.0_"
         sdk = Gigya.sharedInstance(accountSchema)
         GigyaAuth.shared.register(scheme: accountSchema)
     }
@@ -43,12 +73,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 let json = data.mapValues { $0.value }.asJson
                 result(json)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         }
     }
@@ -73,12 +98,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
             case .failure(let error):
                 self?.saveResolvesIfNeeded(interruption: error.interruption)
                 
-                switch error.error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error.error))
             }
         }
     }
@@ -103,12 +123,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
             case .failure(let error):
                 self?.saveResolvesIfNeeded(interruption: error.interruption)
                 
-                switch error.error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error.error))
             }
         }
     }
@@ -132,12 +147,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 let mapped = self?.mapObject(data)
                 result(mapped)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         }
     }
@@ -153,12 +163,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 let mapped = self?.mapObject(data)
                 result(mapped)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         })
     }
@@ -219,12 +224,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
             case .success( _):
                 result(nil)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let d):
-                    result(FlutterError(code: "\(d.errorCode)", message: d.errorMessage, details: d.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         })
     }
@@ -243,12 +243,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 let mapped = self?.mapObject(data)
                 result(mapped)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let d):
-                    result(FlutterError(code: "\(d.errorCode)", message: d.errorMessage, details: d.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         })
     }
@@ -304,12 +299,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 case .failure(let error):
                     self?.saveResolvesIfNeeded(interruption: error.interruption)
                     
-                    switch error.error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error.error))
                 }
             }
     }
@@ -340,12 +330,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 case .failure(let error):
                     self?.saveResolvesIfNeeded(interruption: error.interruption)
                     
-                    switch error.error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error.error))
                 }
             }
     }
@@ -380,12 +365,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                     let mapped = self?.mapObject(data)
                     result(mapped)
                 case .failure(let error):
-                    switch error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error))
                 }
             }
     }
@@ -409,12 +389,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 let returnData = data.mapValues { $0.value }
                 result(returnData)
             case .failure(let error):
-                switch error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error))
             }
         }
     }
@@ -488,7 +463,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
         
         if #available(iOS 16.0.0, *) {            
             Task { [weak self] in
-                guard let loginResult = await sdk?.webAuthn.login(viewController: viewController)
+                guard let loginResult = await self?.sdk?.webAuthn.login(viewController: viewController)
                 else {
                     result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
                     return
@@ -503,12 +478,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                 case .failure(let error):
                     self?.saveResolvesIfNeeded(interruption: error.interruption)
                     
-                    switch error.error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error.error))
                 }
             }
         } else {
@@ -536,12 +506,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                     let json = data.mapValues { $0.value }.asJson
                     result(json)
                 case .failure(let error):
-                    switch error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error))
                 }
             }
         } else {
@@ -563,12 +528,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                     let json = data.mapValues { $0.value }.asJson
                     result(json)
                 case .failure(let error):
-                    switch error {
-                    case .gigyaError(let ge):
-                        result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                    default:
-                        result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                    }
+                    result(PluginErrors.wrapNetworkError(error: error))
                 }
             }
         } else {
@@ -676,12 +636,7 @@ extension GigyaSdkWrapper {
             case .failure(let error):
                 self.saveResolvesIfNeeded(interruption: error.interruption)
 
-                switch error.error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error.error))
             case .pendingOtpVerification(resolver: let resolver):
                 self.resolverHelper.pendingOtpResolver = resolver
                 let data = resolver.data?.mapValues { value in ((value as? AnyCodable) ?? AnyCodable.init("")).value }
@@ -710,12 +665,7 @@ extension GigyaSdkWrapper {
             case .failure(let error):
                 self.saveResolvesIfNeeded(interruption: error.interruption)
 
-                switch error.error {
-                case .gigyaError(let ge):
-                    result(FlutterError(code: "\(ge.errorCode)", message: ge.errorMessage, details: ge.toDictionary()))
-                default:
-                    result(FlutterError(code: PluginErrors.generalError, message: PluginErrors.generalErrorMessage, details: nil))
-                }
+                result(PluginErrors.wrapNetworkError(error: error.error))
             case .pendingOtpVerification(resolver: let resolver):
                 self.resolverHelper.pendingOtpResolver = resolver
 

--- a/lib/src/models/gigya_error.dart
+++ b/lib/src/models/gigya_error.dart
@@ -15,26 +15,21 @@ class GigyaError implements Exception {
 
   /// Construct a [GigyaError] from the given [exception].
   factory GigyaError.fromPlatformException(PlatformException exception) {
-    // Upcast to Object? because with dynamic there are no type checks,
-    // which also prevents type promotion.
-    final Object? details = exception.details as Object?;
+    final Object? details = exception.details;
 
-    if (details is Map<String, dynamic>) {
-      final String? errorDetails = details['errorDetails'] as String?;
-      final String? localizedMessage = details['localizedMessage'] as String?;
-
-      return GigyaError(
-        apiVersion: details['apiVersion'] as int?,
-        callId: details['callId']?.toString(),
-        errorCode: details['errorCode'] as int?,
-        errorDetails: errorDetails ?? localizedMessage,
-        registrationToken: details['regToken'] as String?,
-        statusCode: details['statusCode'] as int?,
-        statusReason: details['statusReason'] as String?,
-      );
+    if (details is! Map<Object?, Object?>) {
+      return const GigyaError();
     }
 
-    return const GigyaError();
+    return GigyaError(
+      apiVersion: details['apiVersion'] as int,
+      callId: details['callId'] as String?,
+      errorCode: details['errorCode'] as int?,
+      errorDetails: details['errorDetails'] as String?,
+      registrationToken: details['regToken'] as String?,
+      statusCode: details['statusCode'] as int?,
+      statusReason: details['statusReason'] as String?,
+    );
   }
 
   /// The version number of the Gigya API.

--- a/lib/src/models/gigya_error.dart
+++ b/lib/src/models/gigya_error.dart
@@ -6,11 +6,9 @@ class GigyaError implements Exception {
   const GigyaError({
     this.apiVersion,
     this.callId,
+    this.details = const <String, Object?>{},
     this.errorCode,
-    this.errorDetails,
-    this.registrationToken,
-    this.statusCode,
-    this.statusReason,
+    this.errorMessage,
   });
 
   /// Construct a [GigyaError] from the given [exception].
@@ -21,14 +19,19 @@ class GigyaError implements Exception {
       return const GigyaError();
     }
 
+    // Remove the specific error details, to avoid including them twice.
+    final int apiVersion = details.remove('apiVersion') as int;
+    final String? callId = details.remove('callId') as String?;
+    final int? errorCode = details.remove('errorCode') as int?;
+    final String? errorMessage = details.remove('errorMessage') as String? ??
+        details.remove('errorDetails') as String?;
+
     return GigyaError(
-      apiVersion: details['apiVersion'] as int,
-      callId: details['callId'] as String?,
-      errorCode: details['errorCode'] as int?,
-      errorDetails: details['errorDetails'] as String?,
-      registrationToken: details['regToken'] as String?,
-      statusCode: details['statusCode'] as int?,
-      statusReason: details['statusReason'] as String?,
+      apiVersion: apiVersion,
+      callId: callId,
+      details: details.cast<String, Object?>(),
+      errorCode: errorCode,
+      errorMessage: errorMessage,
     );
   }
 
@@ -38,28 +41,33 @@ class GigyaError implements Exception {
   /// The call id of the response.
   final String? callId;
 
+  /// The additional error details.
+  final Map<String, Object?> details;
+
   /// The Gigya error code of the response.
   final int? errorCode;
 
-  /// The error details of the response.
-  final String? errorDetails;
+  /// The error message for the given [errorCode].
+  ///
+  /// This is typically only an error message.
+  ///
+  /// This will contain the `errorMessage` from the underlying error,
+  /// or the `errorDetails` if the error message is not available.
+  final String? errorMessage;
 
-  /// The registration token.
-  final String? registrationToken;
-
-  /// The response status code.
-  final int? statusCode;
-
-  /// The reason for the given [statusCode].
-  final String? statusReason;
+  /// Get the registration token from the error.
+  ///
+  /// This is null if the registration token is not available.
+  String? get registrationToken => details['regToken'] as String?;
 
   @override
   String toString() {
     return 'GigyaError('
+        'apiVersion: $apiVersion, '
+        'callId: $callId, '
+        'details: $details, '
         'errorCode: $errorCode, '
-        'errorDetails: $errorDetails, '
-        'statusCode: $statusCode, '
-        'statusReason: $statusReason'
+        'errorMessage: $errorMessage, '
         ')';
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/SAP/gigya-flutter-plugin
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
   flutter: ">=3.3.0"
 
 dependencies:


### PR DESCRIPTION
This PR fixes the GigyaError.fromPlatform() constructor, which didn't account for `Map` being a `Map<Object?, Object?>` across the MethodChannel. I also fixed a bug where not all the error details are included. Now these are available in the `details` Map. For consistency, the `errorDetails` property has been renamed to `errorMessage`. It uses the `errorMessage` or `errorDetails` depending on what is available.

It also cleans up Swift error handling by moving the cases into a separate method and making them explicit.
Lastly, I also bumped the Dart SDK upper constraint to `<4.0.0`, so that anyone who is already using Dart 3.0 can use the package. Apps targeting Dart 2.12 or higher are Dart 3 compatible. 

Fixes #48 
Fixes #46 
Fixes #62 

@tal-mi Can this be released as 1.0.1 ? Unfortunately without this fix, the plugin's error handling is broken, so this might need a bit more priority.