### PR TITLE
Gigya Android - Introduce proguard file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
+        consumerProguardFiles 'lib-proguard-rules.txt'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/lib-proguard-rules.txt
+++ b/android/lib-proguard-rules.txt
@@ -1,0 +1,1 @@
+-keep class com.gigya.** { *; }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -102,7 +102,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   google_sign_in:
     dependency: "direct main"
     description:


### PR DESCRIPTION
This PR is a "fix" for android release builds which experience `Unhandled Exception: MissingPluginException(No implementation found for method isLoggedIn on channel com.sap.gigya_flutter_plugin/methods)`.

It introduces proguard file on android which prevents obfuscation of gigya components in release builds.

Wildcard(ing) `com.gigya.**` will make all components from this package not obfuscated during minification process effectively fixing all release builds to not fail upon interacting with gigya sdk. 

[Raised issue](https://github.com/SAP/gigya-flutter-plugin/issues/67)