### PR TITLE
Allow nullable apiVersion in GigyaError parsing

### DIFF
--- a/lib/src/models/gigya_error.dart
+++ b/lib/src/models/gigya_error.dart
@@ -20,7 +20,7 @@ class GigyaError implements Exception {
     }
 
     // Remove the specific error details, to avoid including them twice.
-    final int apiVersion = details.remove('apiVersion') as int;
+    final int? apiVersion = details.remove('apiVersion') as int?;
     final String? callId = details.remove('callId') as String?;
     final int? errorCode = details.remove('errorCode') as int?;
     final String? errorMessage = details.remove('errorMessage') as String? ??


### PR DESCRIPTION
This PR fixes a bad cast, since the API version is not always in the error details.

It was the only one that forced a non-null value.

Fixes #74 