### PR TITLE
Fix dismiss screenset result for iOS

### DIFF
--- a/ios/Classes/GigyaSdkWrapper.swift
+++ b/ios/Classes/GigyaSdkWrapper.swift
@@ -425,11 +425,12 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
                     handler.addScreenSetEvent(event: ["event":"onHide", "data" : event])
                 case .onLogin(account: let account):
                     let session = self?.sdk?.getSession()
-                    let seesionObject = ["sessionInfo": ["sessionToken": session?.token ?? "", "sessionSecret": session?.secret ?? "", "expires_in": session?.sessionExpirationTimestamp ?? "0"]]
+                    let sessionObject = ["sessionInfo": ["sessionToken": session?.token ?? "", "sessionSecret": session?.secret ?? "", "expires_in": session?.sessionExpirationTimestamp ?? "0"]]
                     var accountObj = self?.mapObject(account)
-                    accountObj?.merge(seesionObject) { _, new  in new }
+                    accountObj?.merge(sessionObject) { _, new  in new }
                     
-                    handler.addScreenSetEvent(event: ["event":"onLogin", "data" : accountObj ?? [:]])                case .onLogout:
+                    handler.addScreenSetEvent(event: ["event":"onLogin", "data" : accountObj ?? [:]])
+                case .onLogout:
                     handler.addScreenSetEvent(event: ["event":"onLogout"])
                 case .onConnectionAdded:
                     handler.addScreenSetEvent(event: ["event":"onConnectionAdded"])
@@ -467,6 +468,7 @@ public class GigyaSdkWrapper<T: GigyaAccountProtocol> :GigyaInstanceProtocol {
         }
         
         viewController.dismiss(animated: true)
+        result(nil)
     }
     
     func webAuthnLogin(result: @escaping FlutterResult) {

--- a/lib/gigya_flutter_plugin.dart
+++ b/lib/gigya_flutter_plugin.dart
@@ -201,6 +201,7 @@ class GigyaSdk {
     );
   }
 
+  /// Dismiss the currently shown screenset.
   Future<void> dismissScreenSet() {
     return GigyaFlutterPluginPlatform.instance.dismissScreenSet();
   }

--- a/lib/src/platform_interface/gigya_flutter_plugin_platform_interface.dart
+++ b/lib/src/platform_interface/gigya_flutter_plugin_platform_interface.dart
@@ -175,6 +175,7 @@ abstract class GigyaFlutterPluginPlatform extends PlatformInterface {
     throw UnimplementedError('showScreenSet() is not implemented.');
   }
 
+  /// Dismiss the currently shown screenset.
   Future<void> dismissScreenSet() {
     throw UnimplementedError('dismissScreenSet() is not implemented.');
   }


### PR DESCRIPTION
This PR fixes `dimissScreenset()` for iOS and adds documentation for the method, which was reported missing by `dart analyze .`